### PR TITLE
support tugg-api locally 

### DIFF
--- a/lib/tugg_api/client.rb
+++ b/lib/tugg_api/client.rb
@@ -9,6 +9,10 @@ module TuggApi
       @api_version = api_version
     end
 
+    def use_localhost?
+      ENV['USE_LOCAL'].present?
+    end
+
     # expects:
       # api_type: 'titles' or 'events'
       # id of event or title
@@ -32,7 +36,12 @@ module TuggApi
           path: "api/#{api_type}/#{id}.#{format}",
           head: {'TUGG-API-KEY' => @api_key, 'TUGG-API-VERSION' => @api_version}
         }
-        http = EventMachine::HttpRequest.new('https://www.tugg.com/', conn_options).get req_options
+
+        if use_localhost?
+          http = EventMachine::HttpRequest.new('http://localhost:3000/', conn_options).get req_options
+        else  
+          http = EventMachine::HttpRequest.new('https://www.tugg.com/', conn_options).get req_options
+        end
 
         http.errback do
           response = http.response

--- a/lib/tugg_api/client.rb
+++ b/lib/tugg_api/client.rb
@@ -57,25 +57,26 @@ module TuggApi
  
     #looking for options passed to rails server/console
     #requires server name to be specified, e.g. '$ rails s webrick tugg-local' bc of order specific argument passing in rails
+    #assumes 'http://localhost:3000' unless specified via tugg-[domain||port] options
     def use_localhost?
       ARGV.include?('tugg-local')
     end
     
+    #usage: '$ rails c development tugg-local tugg-port 3001'
     def port?
       get_port if ARGV.include?('tugg-port')
     end
     
-    #usage: '$ rails c development tugg-local tugg-port 3001'
-    def get_port
-      pos = ARGV.index('tugg-port').next
-      ARGV[pos]
+    #usage: '$ rails c development tugg-local tugg-domain mybox.dev'
+    def domain?
+      get_domain if ARGV.include?('tugg-domain')
     end
 
     #domain builder utilities
     def build_url
       if use_localhost?
         http = protocol('http')
-        domain = hostname('localhost')
+        domain = hostname(domain? || 'localhost')
         port = api_port(port? || 3000) 
       else
         http = protocol
@@ -95,6 +96,18 @@ module TuggApi
 
     def protocol(protocol= 'https')
       protocol
+    end
+
+    private
+
+    def get_port
+      pos = ARGV.index('tugg-port').next
+      ARGV[pos]
+    end
+    
+    def get_domain
+      pos = ARGV.index('tugg-domain').next
+      ARGV[pos]
     end
 
   end


### PR DESCRIPTION
usage: `LOCAL=1 rails (console/server) development`
and optionally as params:

`TuggApi::Client.new('TOKEN', {api_host:'local.dev', api_protocol: 'http', api_port: 3000})`
